### PR TITLE
feat: Js bundle version 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ public/tinymce/*
 
 # Vite runtime files
 vite.config.ts.timestamp-*.mjs
+
+.rollup.cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
 				"@rollup/plugin-json": "^6.1.0",
 				"@rollup/plugin-node-resolve": "^15.2.3",
 				"@rollup/plugin-replace": "^5.0.5",
+				"@rollup/plugin-typescript": "^11.1.6",
 				"@storybook/addon-a11y": "^7.6.17",
 				"@storybook/addon-actions": "^7.6.17",
 				"@storybook/addon-essentials": "^7.6.17",
@@ -4251,6 +4252,32 @@
 			},
 			"peerDependenciesMeta": {
 				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rollup/plugin-typescript": {
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.6.tgz",
+			"integrity": "sha512-R92yOmIACgYdJ7dJ97p4K69I8gg6IEHt8M7dUBxN3W6nrO8uUxX5ixl0yU/N3aZTi8WhPuICvOHXQvF6FaykAA==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^5.1.0",
+				"resolve": "^1.22.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^2.14.0||^3.0.0||^4.0.0",
+				"tslib": "*",
+				"typescript": ">=3.7.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				},
+				"tslib": {
 					"optional": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
 		"@rollup/plugin-json": "^6.1.0",
 		"@rollup/plugin-node-resolve": "^15.2.3",
 		"@rollup/plugin-replace": "^5.0.5",
+		"@rollup/plugin-typescript": "^11.1.6",
 		"@storybook/addon-a11y": "^7.6.17",
 		"@storybook/addon-actions": "^7.6.17",
 		"@storybook/addon-essentials": "^7.6.17",

--- a/src/rollup.config.js
+++ b/src/rollup.config.js
@@ -6,6 +6,7 @@ import webWorkerLoader from 'rollup-plugin-web-worker-loader';
 import replace from '@rollup/plugin-replace';
 import { readdirSync, lstatSync, cpSync, copyFileSync, existsSync, unlinkSync } from 'fs';
 import * as globModule from 'tiny-glob';
+import typescript from '@rollup/plugin-typescript';
 
 const glob = globModule.default;
 
@@ -92,5 +93,32 @@ const libraries = allowed.map((module) => {
 	};
 });
 
+const components =  {
+	input: './src/apps/app/index.ts',
+	output: {
+		dir: `${DIST_DIRECTORY}/test/bundle`,
+		format: 'es'
+	},
+	plugins: [
+		commonjs(),
+		nodeResolve({ preferBuiltins: false, browser: true }),
+		webWorkerLoader({ target: 'browser', pattern: /^(.+)\?worker$/ }),
+		// Replace the vite specific inline query with nothing so that the import is valid
+		replace({
+			preventAssignment: true,
+			values: {
+				'?inline': '',
+			}
+		}),
+		css({ minify: true }),
+		esbuild({ minify: true, sourceMap: true }),
+		typescript({
+			tsconfig: './src/tsconfig.build.json',
+			outDir: `${DIST_DIRECTORY}/test/bundle/typescript`,
+		}),
+	],
+};
+
 /** @type {import('rollup').RollupOptions[]} */
-export default [...libraries];
+export default [...libraries, components];
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

These changes bundles the Backoffice app with rollup.

This was an experiment on reducing the ~2000 requests that the backoffice makes in v14 on first load.

To use the bundled assets the following changes was made in the Umbraco-CMS project:

File: `src\Umbraco.Cms.StaticAssets\umbraco\UmbracoBackOffice\Index.cshtml`
```diff
<head>
    <meta charset="UTF-8" />
    <base href="@backOfficePath.EnsureEndsWith('/')" />
    <link rel="icon" type="image/svg+xml" href="@backOfficeAssetsPath/assets/favicon.svg" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <meta name="apple-mobile-web-app-capable" content="yes"/>
    <meta name="robots" content="noindex, nofollow"/>
    <meta name="pinterest" content="nopin"/>
    <title>Umbraco</title>

    <link rel="stylesheet" href="@backOfficeAssetsPath/css/user-defined.css" />
    <link rel="stylesheet" href="@backOfficeAssetsPath/css/umb-css.css" />
    <link rel="stylesheet" href="@backOfficeAssetsPath/css/uui-css.css" />
-   @await Html.BackOfficeImportMapScriptAsync(JsonSerializer, BackOfficePathGenerator, PackageManifestService)
-    <script type="module" src="@backOfficeAssetsPath/apps/app/app.element.js"></script>
+    <script type="module" src="@backOfficeAssetsPath/test/bundle/index.js"></script>
</head>
```

## Testing

For this change, I did some before and after testing (See results below).

The testing was done in incognito without any extensions activated.
Furthermore, the testing was done in debugging mode from Visual Studio.
All results are from Chrome (Network tab & Lighthouse).

The Umbraco instance was a fresh boot without content and only the landing page `/umbraco/section/content/dashboard/dashboardTabsContentIntro` was refreshed.

The refresh was done by clearing the Network tab in devtools and pressing the refresh button with CTRL down for a hard refresh.

From the results below I think it's safe to say that this change greatly improves the performance for loading the backoffice.

## Results

### Before:
URL: `https://localhost:44360/umbraco/section/content/dashboard/dashboardTabsContentIntro`

| Requests | MB transferred | MB resources | Finish | DOMContentLoaded | Load |
|-----------|------------------|----------------|--------|------------------------|-------|
| 2093       | 3.9 MB              | 3.8 MB            | 3.63 s  | 1.56 s                        | 1.56 s |

<details>
  <summary>Screenshot</summary>
  
  ![image](https://github.com/umbraco/Umbraco.CMS.Backoffice/assets/24605285/821c286c-9c29-487d-a786-5c8548c52c34)
</details>

Lighthouse:
![image](https://github.com/nikcio/Umbraco.CMS.Backoffice/assets/24605285/2d0c70f6-90f2-4fab-bbc6-28fad9d1afd8)
![image](https://github.com/nikcio/Umbraco.CMS.Backoffice/assets/24605285/9edffa74-c98d-40b5-bcd4-e350ef3c11b6)


### Before with compression

<details>
  <summary>Code added to program.cs</summary>
  
  ```diff
  WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
  
  builder.CreateUmbracoBuilder()
      .AddBackOffice()
      .AddWebsite()
      .AddDeliveryApi()
      .AddComposers()
      .Build();
  
  +builder.Services.AddResponseCompression(options =>
  +{
  +    options.EnableForHttps = true;
  +});
  
  WebApplication app = builder.Build();
  
  await app.BootUmbracoAsync();
  
  +app.UseResponseCompression();
  
  app.UseUmbraco()
      .WithMiddleware(u =>
      {
          u.UseBackOffice();
          u.UseWebsite();
      })
      .WithEndpoints(u =>
      {
          u.UseBackOfficeEndpoints();
          u.UseWebsiteEndpoints();
      });
  
  await app.RunAsync();
  ```
</details>

URL: `https://localhost:44360/umbraco/section/content/dashboard/dashboardTabsContentIntro`

| Requests | MB transferred | MB resources | Finish | DOMContentLoaded | Load |
|-----------|------------------|----------------|--------|------------------------|-------|
| 2088       | 1.5 MB              | 3.6 MB            | 3.55 s  | 1.48 s                        | 1.48 s |

<details>
  <summary>Screenshot</summary>
  
  
  ![image](https://github.com/nikcio/Umbraco.CMS.Backoffice/assets/24605285/66d22698-12c4-42fa-a4fe-dfcbe9c8a296)

</details>

Lighthouse:
![image](https://github.com/nikcio/Umbraco.CMS.Backoffice/assets/24605285/a892c102-8a9e-4f81-9868-3aef0b23349e)
![image](https://github.com/nikcio/Umbraco.CMS.Backoffice/assets/24605285/07a346ca-c962-4c57-85e4-ed20446155ca)

### After
URL: `https://localhost:44339/umbraco/section/content/dashboard/dashboardTabsContentIntro`

| Requests | MB transferred | MB resources | Finish | DOMContentLoaded | Load |
|-----------|------------------|----------------|--------|------------------------|-------|
| 138         | 2.3 MB              | 2.3 MB            | 547 ms  | 88 ms                      | 89 ms |

<details>
  <summary>Screenshot</summary>
  
  
  ![image](https://github.com/nikcio/Umbraco.CMS.Backoffice/assets/24605285/769e8763-7451-483f-9189-14a5061ebdd8)

</details>

Lighthouse:
![image](https://github.com/nikcio/Umbraco.CMS.Backoffice/assets/24605285/78478011-2926-45ce-b383-9f5585ee3340)
![image](https://github.com/nikcio/Umbraco.CMS.Backoffice/assets/24605285/5fa18a6a-5e96-488c-aef2-d8b047cb31e7)

### After with compression

<details>
  <summary>Code added to program.cs</summary>
  
  ```diff
  WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
  
  builder.CreateUmbracoBuilder()
      .AddBackOffice()
      .AddWebsite()
      .AddDeliveryApi()
      .AddComposers()
      .Build();
  
  +builder.Services.AddResponseCompression(options =>
  +{
  +    options.EnableForHttps = true;
  +});
  
  WebApplication app = builder.Build();
  
  await app.BootUmbracoAsync();
  
  +app.UseResponseCompression();
  
  app.UseUmbraco()
      .WithMiddleware(u =>
      {
          u.UseBackOffice();
          u.UseWebsite();
      })
      .WithEndpoints(u =>
      {
          u.UseBackOfficeEndpoints();
          u.UseWebsiteEndpoints();
      });
  
  await app.RunAsync();
  ```
</details>

URL: `https://localhost:44339/umbraco/section/content/dashboard/dashboardTabsContentIntro`

| Requests | MB transferred | MB resources | Finish | DOMContentLoaded | Load |
|-----------|------------------|----------------|--------|------------------------|-------|
| 133         | 795 kB              | 2.1 MB            | 598 ms  | 97 ms                     | 97 ms |

<details>
  <summary>Screenshot</summary>
  
  ![image](https://github.com/nikcio/Umbraco.CMS.Backoffice/assets/24605285/006e179d-780d-4573-a7a1-3645e5d6db16)

</details>

Lighthouse:
![image](https://github.com/nikcio/Umbraco.CMS.Backoffice/assets/24605285/25509c96-b9a7-4066-bab7-7c7356753973)
![image](https://github.com/nikcio/Umbraco.CMS.Backoffice/assets/24605285/083d8e5c-b779-4e59-8be9-aad043d9f105)

## Updates to docs?

From my testing it's clear that response compression greatly improves the asset performance. We should add this to the Umbraco docs but I'm not sure where it makes best sense.

## Next steps

This PR is right now configured to create the bundled elements in a `test` directory we need to change this so we use a path that makes sense. We also need to purge the files we don't need in the `dist-cms` folder or export the assets used for the backoffice to another folder so we don't include all the unneeded files in the NuGet package for Umbraco.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bundle optimization (Sorry I made my own)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (minor updates related to the tooling or maintenance of the repository, does not impact compiled assets)

## Motivation and context

This makes the backoffice load much faster.

## How to test?

## Screenshots (if appropriate)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply.  If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] If my change requires a change to the documentation, I have updated the documentation in this pull request.
- [ ] I have read the **[CONTRIBUTING](<(https://github.com/umbraco/Umbraco.CMS.Backoffice/blob/main/.github/CONTRIBUTING.md)>)** document.
- [ ] I have added tests to cover my changes.
